### PR TITLE
Refatora variável de ambiente

### DIFF
--- a/frontend-web/public/index.html
+++ b/frontend-web/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Remote books</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend-web/public/manifest.json
+++ b/frontend-web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Remote Books",
+  "name": "Site que gerencia livros",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend-web/src/requests.ts
+++ b/frontend-web/src/requests.ts
@@ -1,2 +1,2 @@
 /** A url padrão */
-export const BASE_URL = process.env.SERVER_URL ?? "http://localhost:8080"
+export const BASE_URL = process.env.REACT_APP_SERVER_URL ?? "http://localhost:8080"


### PR DESCRIPTION
A mudança foi necessária porque a variável de ambiente no React somente funciona se existir o préfixo `REACT_APP_`