### PR TITLE
Atualiza o comando que roda os testes do backend

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Grant Permissions to gradlew
         run: chmod +x gradlew
 
-      - name: Test
-        run: ./gradlew test
+      - name: Run tests
+        run: ./gradlew clean build check


### PR DESCRIPTION
A alteração foi feita por conta que o comando
./gradlew test não era adequado, por fluxo de
execução, que não engloba plugins.

Implementa #35.